### PR TITLE
Add ProductStatus enum for type-safe product status handling

### DIFF
--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -4,6 +4,7 @@ namespace Lunar\Database\Factories;
 
 use Lunar\FieldTypes\Text;
 use Lunar\Models\Brand;
+use Lunar\Enums\ProductStatus;
 use Lunar\Models\Product;
 use Lunar\Models\ProductType;
 
@@ -15,7 +16,7 @@ class ProductFactory extends BaseFactory
     {
         return [
             'product_type_id' => ProductType::factory(),
-            'status' => 'published',
+            'status' => ProductStatus::Published,
             'brand_id' => Brand::factory()->create()->id,
             'attribute_data' => collect([
                 'name' => new Text($this->faker->name),

--- a/src/Enums/ProductStatus.php
+++ b/src/Enums/ProductStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Lunar\Enums;
+
+enum ProductStatus: string
+{
+    case Published = 'published';
+    case Draft = 'draft';
+}

--- a/src/Models/Product.php
+++ b/src/Models/Product.php
@@ -27,6 +27,7 @@ use Lunar\Base\Traits\HasUrls;
 use Lunar\Base\Traits\LogsActivity;
 use Lunar\Base\Traits\Searchable;
 use Lunar\Database\Factories\ProductFactory;
+use Lunar\Enums\ProductStatus;
 use Lunar\Jobs\Products\Associations\Associate;
 use Lunar\Jobs\Products\Associations\Dissociate;
 use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
@@ -35,7 +36,7 @@ use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
  * @property int $id
  * @property ?int $brand_id
  * @property int $product_type_id
- * @property string $status
+ * @property \Lunar\Enums\ProductStatus $status
  * @property ?\Illuminate\Support\Collection $attribute_data
  * @property ?\Illuminate\Support\Carbon $created_at
  * @property ?\Illuminate\Support\Carbon $updated_at
@@ -83,6 +84,7 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
      */
     protected $casts = [
         'attribute_data' => AsAttributeData::class,
+        'status' => ProductStatus::class,
     ];
 
     /**
@@ -189,9 +191,11 @@ class Product extends BaseModel implements Contracts\Product, HasThumbnailImage,
         return $this->belongsTo(Brand::modelClass());
     }
 
-    public function scopeStatus(Builder $query, string $status): Builder
+    public function scopeStatus(Builder $query, ProductStatus|string $status): Builder
     {
-        return $query->whereStatus($status);
+        $value = $status instanceof ProductStatus ? $status->value : $status;
+
+        return $query->where('status', $value);
     }
 
     public function prices(): HasManyThrough


### PR DESCRIPTION
Introduces `Lunar\Enums\ProductStatus` backed enum with `Published` and `Draft` cases, replacing hardcoded status strings throughout the codebase.

Changes:
- Add `Lunar\Enums\ProductStatus` enum
- Cast `Product::$status` to the enum
- Update `scopeStatus()` to accept both enum and string (backwards compatible)
- Update `ProductFactory` to use enum