### PR TITLE
Change Cart type hint to CartContract in getDiscounts

### DIFF
--- a/src/Managers/DiscountManager.php
+++ b/src/Managers/DiscountManager.php
@@ -9,7 +9,6 @@ use Lunar\Base\DiscountManagerInterface;
 use Lunar\Base\Validation\CouponValidator;
 use Lunar\DiscountTypes\AmountOff;
 use Lunar\DiscountTypes\BuyXGetY;
-use Lunar\Models\Cart;
 use Lunar\Models\Channel;
 use Lunar\Models\Contracts\Cart as CartContract;
 use Lunar\Models\Contracts\Channel as ChannelContract;
@@ -119,7 +118,7 @@ class DiscountManager implements DiscountManagerInterface
     /**
      * Returns the available discounts.
      */
-    public function getDiscounts(?Cart $cart = null): Collection
+    public function getDiscounts(?CartContract $cart = null): Collection
     {
         if ($this->channels->isEmpty() && $defaultChannel = Channel::getDefault()) {
             $this->channel($defaultChannel);


### PR DESCRIPTION
Use Lunar\Models\Contracts\Cart (e.g. CartContract) instead of the concrete Cart model in signatures so code stays aligned with Lunar’s model replacement.